### PR TITLE
Fix minor logic issues

### DIFF
--- a/24-points-23rmyc.py
+++ b/24-points-23rmyc.py
@@ -99,7 +99,8 @@ def addition(item):  # 加法计算函数
     shoot_list = []
     result = item[0] + item[1] + item[2]  # a+b+c
     if result == 24:
-        shoot_list = [item[0], symbol, item[2], item[3]]
+        # 正确的输出应包含三数字与两个加号
+        shoot_list = [item[0], symbol, item[1], symbol, item[2]]
     else:
         result = item[0] + item[1] + item[2] + item[3]  # a+b+c+d
         if result == 24:

--- a/Precise and high-speed movement.py
+++ b/Precise and high-speed movement.py
@@ -37,6 +37,7 @@ variable_y0 = 0
 def start():
     # Please call the function here(move/moveTime/turnToAngle/turn_to_initial)
     # 请在此处调用函数（move/move_with_time/turnToAngle/turn_to_initial)
+    pass
 
 
 def move(s, v, angle) -> None:


### PR DESCRIPTION
## Summary
- fix the addition() path in 24-points solver
- add a `pass` statement so `start()` compiles in Precise and high-speed movement example

## Testing
- `python -m py_compile 24-points-23rmyc.py Auto_22_blue.py Auto_22_red.py RMTT.py 'auto_22_blue-and-red-in-one.py' 'Precise and high-speed movement.py'`

------
https://chatgpt.com/codex/tasks/task_e_685817b8b3d48333827c5f86325146dd